### PR TITLE
Lines 240 to 243 returned floats, should be integers

### DIFF
--- a/sip_to_pv.py
+++ b/sip_to_pv.py
@@ -237,10 +237,10 @@ def remove_sip_keywords(header):
     --------
     None (header is modified in place)
     """
-    aorder = header.get('A_ORDER', 0.0)
-    border = header.get('B_ORDER', 0.0)
-    aporder = header.get('AP_ORDER', 0.0)
-    bporder = header.get('BP_ORDER', 0.0)
+    aorder = int(header.get('A_ORDER', 0.0))
+    border = int(header.get('B_ORDER', 0.0))
+    aporder = int(header.get('AP_ORDER', 0.0))
+    bporder = int(header.get('BP_ORDER', 0.0))
     for m in range(aorder+1):
         for n in range(0,aorder+1-m):
             removekwd(header,'A_%d_%d'%(m,n))


### PR DESCRIPTION
I tried this code on a PTF image and got the following error message:

```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-2-dff8e0aa35ba> in <module>()
----> 1 s2p.sip_to_pv('PTF201203051940_2_o_62108_01.w.fits', 'Output.fits')

/Users/cf5g09/Documents/forks/sip_tpv/sipdev/sip_to_pv.py in sip_to_pv(infile, outfile, tpv_format, preserve, extension, clobber)
    285     add_pv_keywords(header, sipx, sipy, pvrange, tpvx, tpvy, tpv=tpv_format)
    286     if (not preserve):
--> 287         remove_sip_keywords(header)
    288     hdu.writeto(outfile, clobber=clobber)
    289

/Users/cf5g09/Documents/forks/sip_tpv/sipdev/sip_to_pv.py in remove_sip_keywords(header)
    242     aporder = header.get('AP_ORDER', 0.0)
    243     bporder = header.get('BP_ORDER', 0.0)
--> 244     for m in range(aorder+1):
    245         for n in range(0,aorder+1-m):
    246             removekwd(header,'A_%d_%d'%(m,n))

TypeError: range() integer end argument expected, got float.
```

I changed lines 240-243 to be integers so they can be looped through in the next `range` function (line 244).

Now works and creates an Output image that works in astropy.
